### PR TITLE
fix wrong webpack configuration #5

### DIFF
--- a/template/build/webpack.test.conf.js
+++ b/template/build/webpack.test.conf.js
@@ -19,7 +19,7 @@ var webpackConfig = merge(baseConfig, {
           }
         }
       },
-      utils.styleLoaders()
+      ...utils.styleLoaders()
     ]
   },
   devtool: '#inline-source-map',


### PR DESCRIPTION
utils.styleLoaders() return an array of object and needs deconstruct.